### PR TITLE
Release 4.0.4

### DIFF
--- a/.github/actions/update-dep-version/entrypoint.sh
+++ b/.github/actions/update-dep-version/entrypoint.sh
@@ -40,7 +40,7 @@ raw_version=`jq .version package.json`
 version=`echo $raw_version | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
 next_version=`echo $version | awk -F"." '{print $1 FS $2 FS}'`$((`echo $version | awk -F"." '{print $NF}'` + 1))
 sed -i -e "s/\(version\":\).*/\1 \"$next_version\",/" package.json
-npm ci --progress=false && npm i @iconscout/unicons@latest
+npm ci --progress=false --lockfile-version=1 && npm i @iconscout/unicons@latest
 
 git checkout -b "release-$next_version"
 echo "Adding git commit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iconscout/unicons",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Ready to use font icons for your next project",
   "scripts": {
     "font:build": "npm run line:download && npm run line:generate-fontello-config && npm run line:generate && npm run line:build-sprite",


### PR DESCRIPTION
We need package-lock version 1 for sub-packages because they use node 10.x  and npm 6.x in their workflow.
So lets force npm generate package lock v1 while `npm ci`