### PR TITLE
hotfix: added release dir .env variable for NPM publish stage

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,7 @@ jobs:
           API_DOWNLOAD_SOLID: ${{ secrets.API_DOWNLOAD_SOLID }}
           API_DOWNLOAD_THINLINE: ${{ secrets.API_DOWNLOAD_THINLINE }}
           API_DOWNLOAD_MONOCHROME: ${{ secrets.API_DOWNLOAD_MONOCHROME }}
+          RELEASE_DIR: 'release'
       - name: Publish to CDN
         uses: jakejarvis/s3-sync-action@master
         with:


### PR DESCRIPTION
Somehow this stage did not had release dir env variable.
Webpack needed it and thats why it failed.
So lets try adding default release dir for free unicons