### PR TITLE
try: exclude github dir from uploading

### DIFF
--- a/.github/workflows/npm-publish-pro.yml
+++ b/.github/workflows/npm-publish-pro.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish to CDN
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*'
+          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*' --exclude 'github/*'
         env:
           AWS_S3_BUCKET: 'unicons-iconscout-a5996f0'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/npm-publish-rc-pro.yml
+++ b/.github/workflows/npm-publish-rc-pro.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Publish to CDN
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*'
+          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*' --exclude 'github/*'
         env:
           AWS_S3_BUCKET: 'unicons-iconscout-a5996f0'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/npm-publish-rc.yml
+++ b/.github/workflows/npm-publish-rc.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Publish to CDN
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*'
+          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*' --exclude 'github/*'
         env:
           AWS_S3_BUCKET: 'unicons-iconscout-a5996f0'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish to CDN
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*'
+          args: --no-progress --exclude '.git/*' --exclude 'node_modules/*' --exclude 'build/*' --exclude '.github/*' --exclude 'github/*'
         env:
           AWS_S3_BUCKET: 'unicons-iconscout-a5996f0'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Issue: Last build failed at Upload to CDN step, with non zero error after uploading
There is no error in log, all files are uploaded successfully, but the step is getting exit

we are using this package   jakejarvis/s3-sync-action@master for uploading to s3
in logs i found that it is trying to upload one file that is not there in repo, 

```warning: Skipping file /github/workspace/node_modules/ttf2woff2/build/node_gyp_bins/python3. File does not exist.```

One probability is s3 internally from this package throwing non zero for this.

Lets try to explicitly exclude this dir.
